### PR TITLE
Fix melbourne 3.2 build on Rubinius

### DIFF
--- a/ext/rubinius/code/melbourne/extconf.rb
+++ b/ext/rubinius/code/melbourne/extconf.rb
@@ -1,4 +1,4 @@
-require 'rbconfig'
+require 'rbconfig' unless defined?(RbConfig)
 
 require File.expand_path("../../../../../lib/rubinius/code/melbourne/version", __FILE__)
 


### PR DESCRIPTION
This probably was lost somehow from 3.1.
