### PR TITLE
Include filename in compiler eval cache key

### DIFF
--- a/lib/rubinius/code/compiler/compiler.rb
+++ b/lib/rubinius/code/compiler/compiler.rb
@@ -286,7 +286,7 @@ module CodeTools
     def self.compile_eval(string, variable_scope, file="(eval)", line=1)
       if ec = @eval_cache
         layout = variable_scope.local_layout
-        if code = ec.retrieve([string, layout, line])
+        if code = ec.retrieve([string, layout, file, line])
           return code
         end
       end
@@ -305,7 +305,7 @@ module CodeTools
       code.add_metadata :for_eval, true
 
       if ec and parser.should_cache?
-        ec.set([string.dup, layout, line], code)
+        ec.set([string.dup, layout, file, line], code)
       end
 
       return code


### PR DESCRIPTION
For a case [like this](https://github.com/rspec/rspec-core/blob/5c14942154d83af84cc5ce7e95ecda1423c2a91d/spec/rspec/core/formatters/base_text_formatter_spec.rb#L69) where `filename` could change for the same eval-ed snippet, subsequent calls to `Compiler.compile_eval` would return a `CompiledCode` with the first `filename` used.
