### PR TITLE
Allow uninitialized block locals to be used in nested scopes.

### DIFF
--- a/lib/rubinius/code/ast/sends.rb
+++ b/lib/rubinius/code/ast/sends.rb
@@ -547,7 +547,7 @@ module CodeTools
         if variable = variables[name]
           variable.nested_reference
         elsif block_local?(name)
-          new_local name
+          new_nested_local name
         elsif reference = @parent.search_local(name)
           reference.depth += 1
           reference


### PR DESCRIPTION
When #search_local is called on the parent scope, it first looks for
`variables` that match the name. If a block local was not initialized
in its original scope, it would not have been stored in `variables`
through #assign_local_reference. Thus, it reaches the #block_local?
check in #search_local. At that point, the variable is going to be
used within a nested scope, so the returned value must be a
NestedLocalReference instead of a LocalVariable.

Fix for the spec in rubinius/rubinius#3641
