### PR TITLE
[WIP] for adding Ruby 2.3 heredoc

### DIFF
--- a/ext/rubinius/code/melbourne/grammar.cpp
+++ b/ext/rubinius/code/melbourne/grammar.cpp
@@ -9985,6 +9985,11 @@ parser_heredoc_identifier(rb_parser_state* parser_state)
     c = nextc();
     func = STR_FUNC_INDENT;
   }
+  if(c == '~') {
+    c = nextc();
+    func = STR_FUNC_INDENT;
+  }
+  // HERE - tomkad
   switch(c) {
   case '\'':
     func |= str_squote; goto quoted;


### PR DESCRIPTION
WIP for https://github.com/rubinius/rubinius/issues/3602

Creating this PR after speaking to @brixen on Gitter. The problem that I am having is that running `<<~HEREDOC` in irb creates a syntax error: `SyntaxError: syntax error, unexpected tLSHFT: (irb):1:2`. I'm not sure which part of the code is responsible for producing this error.
